### PR TITLE
Script to Download Images

### DIFF
--- a/download.py
+++ b/download.py
@@ -1,0 +1,50 @@
+import requests
+import os.path
+import sqlite3
+import urllib3
+
+# Squash SSL authentication warnings
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+working_dir = os.getcwd()
+images = os.path.join(working_dir, "images")
+try:
+    os.mkdir(images)
+except OSError:
+    print("Cannot create image directory at " + working_dir)
+else:
+    print("Image directory created")
+
+# Load DB
+conn = sqlite3.connect('/Users/conor/GroupMeHistory/chat.db')
+c = conn.cursor()
+
+# Retrieve the URLs that are hosted by groupme
+results = c.execute("SELECT * from messages where attachment_url is not null and attachment_url like '%i.groupme.com%'")
+
+printed = 0
+
+# Retreive file names and download new files
+for rnum, row in enumerate(results):
+    URL = row[4]
+    file_name = ''
+    if 'jpeg'  in URL:
+        temp = URL.split(".jpeg.", 1)
+        file_name = temp[1] + '.jpeg'
+    elif 'gif' in URL:
+        temp = URL.split(".gif.", 1)
+        file_name = temp[1] + '.gif'
+    elif 'png' in URL:
+        temp = URL.split(".png.", 1)
+        file_name = temp[1] + '.png'
+
+    with open(os.path.join(images, file_name), 'wb') as f:
+        resp = requests.get(URL, verify=False)
+
+        if not os.path.exists(file_name):
+            printed += 1
+            print(str(rnum) + ": Writing " + file_name)
+            f.write(resp.content)
+        else:
+            print("File already downloaded")
+print("Saved " + str(printed) + " files to " + images)


### PR DESCRIPTION
For archival purposes it may be beneficial to have the images stored locally and not hosted on groupme. 
Images are named according to the hashes groupme assigns them.
Future improvements would be to append the sender to the filename for easier searching, however this is not a current priority. 

I made this script as part of a larger project to make the chat database more human-readable. I'm working on creating a web interface to allow people to easily search the database and as a part of this I wanted to be able to display all images in the database instead of just links.